### PR TITLE
Introducing one_liner flag

### DIFF
--- a/lib/mumukit/content_type.rb
+++ b/lib/mumukit/content_type.rb
@@ -9,7 +9,7 @@ module Mumukit
       end
 
       def to_html(content, options={})
-        content_html = htmlize content
+        content_html = htmlize content, options
         content_html = Mumukit::ContentType::Sanitizer.sanitize(content_html) unless options[:skip_sanitization]
         content_html&.html_safe
       end

--- a/lib/mumukit/content_type/html.rb
+++ b/lib/mumukit/content_type/html.rb
@@ -9,7 +9,7 @@ module Mumukit::ContentType::Html
     "<pre>#{code}</pre>"
   end
 
-  def self.htmlize(content)
+  def self.htmlize(content, _options)
     content
   end
 

--- a/lib/mumukit/content_type/markdown.rb
+++ b/lib/mumukit/content_type/markdown.rb
@@ -17,7 +17,18 @@ module Mumukit::ContentType::Markdown
     end
   end
 
-  @@markdown = Redcarpet::Markdown.new(HTML, autolink: true, fenced_code_blocks: true, no_intra_emphasis: true, tables: true)
+  class OneLinerHTML < HTML
+    def paragraph(text)
+      text
+    end
+  end
+
+  def self.new_markdown(renderer)
+    Redcarpet::Markdown.new(renderer, autolink: true, fenced_code_blocks: true, no_intra_emphasis: true, tables: true)
+  end
+
+  @@markdown = new_markdown HTML
+  @@one_liner_markdown = new_markdown OneLinerHTML
 
   def self.title(title)
     "**#{title}**"
@@ -35,16 +46,20 @@ module Mumukit::ContentType::Markdown
     "`#{code}`"
   end
 
-  def self.replace_mu_logo(content)
+  def self.render_replacing_mu_logo(content, renderer)
     mumuki_logo = '<i class="text-primary da da-mumuki"></i>'
-    @@markdown
+    renderer
         .render(content)
         .gsub('<span class="err">ム</span>', mumuki_logo)
         .gsub('ム', mumuki_logo)
   end
 
-  def self.htmlize(content)
-    replace_mu_logo(content) if content
+  def self.htmlize(content, options)
+    render_replacing_mu_logo(content, renderer_for(options)) if content
+  end
+
+  def self.renderer_for(options)
+    options[:one_liner] ? @@one_liner_markdown : @@markdown
   end
 
   def self.name

--- a/spec/content_type_spec.rb
+++ b/spec/content_type_spec.rb
@@ -37,6 +37,9 @@ describe Mumukit::ContentType do
     it { expect(markdown.to_html("ム foo\nム bar\n")).to_not include "ム" }
     it { expect(markdown.to_html('[this is a link somewhere with a title](http://www.somewhere.com "title here")')).to eq "<p><a title=\"title here\" href=\"http://www.somewhere.com\" target=\"_blank\">this is a link somewhere with a title</a></p>\n" }
     it { expect(markdown.to_html('<script></script>')).to eq "\n" }
+
+    it { expect(markdown.to_html('hello `code`')).to eq "<p>hello <code>code</code></p>\n" }
+    it { expect(markdown.to_html('hello `code`', one_liner: true)).to eq "hello <code>code</code>" }
   end
 
   describe 'highlighted_code' do


### PR DESCRIPTION
Allowing markdown to be rendered without `<p>` wraps